### PR TITLE
Use github.getOctokit() insted of github.GitHub() for @actions/github

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ try {
 }
 
 async function pullRequestReviews({token, prNumber, message, eventType}) {
-  const octokit = new github.GitHub(token)
+  const octokit = github.getOctokit(token)
   await octokit.pulls
     .createReview({
       owner: github.context.repo.owner,


### PR DESCRIPTION
`github.GitHub()` seems to be deprecated on recent `@actions/github` version (from v3~ ?).
So this PR changes from `new github.GitHub()` to `github.getOctokit()` to create github client.

https://github.com/actions/toolkit/tree/main/packages/github


Current output in GitHub Actions below
```bash
Run golfzaptw/action-auto-reviews-from-branches@1.2.2
  with:
    GITHUB_TOKEN: ***
    EVENT_TYPE: APPROVE
    AUTHOR: evalphobia
    MESSAGE: Approved 🐶 Uo･ｪ･oU 🏳️‍🌈🎉
    BRANCHES: release/*
  env:
    valid_actors: evalphobia
/usr/bin/docker run --name aa2ea65f01a4c98a8365efded43b967_88cc09 --label 189393 --workdir /github/workspace --rm -e valid_actors -e INPUT_GITHUB_TOKEN -e INPUT_EVENT_TYPE -e INPUT_AUTHOR -e INPUT_MESSAGE -e INPUT_BRANCHES -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/my-private-repo/my-private-repo":"/github/workspace" 189393:6aa2ea65f02a4c98a9765efded43b968

(node:1) UnhandledPromiseRejectionWarning: TypeError: github.GitHub is not a constructor
    at pullRequestReviews (/index.js:67:19)
    at Object.<anonymous> (/index.js:48:9)
    at Module._compile (internal/modules/cjs/loader.js:1015:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1035:10)
    at Module.load (internal/modules/cjs/loader.js:879:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47
```